### PR TITLE
feat(email): add the missing REST API parameter disable_email_click_tracking

### DIFF
--- a/models/Notification.ts
+++ b/models/Notification.ts
@@ -397,6 +397,10 @@ export class Notification {
     */
     'email_preheader'?: string;
     /**
+    * Channel: Email Default is `false`. If set to `true`, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked. 
+    */
+    'disable_email_click_tracking'?: boolean;
+    /**
     * Channel: Email Default is `false`. This field is used to send transactional notifications. If set to `true`, this notification will also be sent to unsubscribed emails. If a `template_id` is provided, the `include_unsubscribed` value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP\'s list of unsubscribed emails to be cleared.
     */
     'include_unsubscribed'?: boolean;
@@ -1026,6 +1030,12 @@ export class Notification {
             "baseName": "email_preheader",
             "type": "string",
             "format": ""
+        },
+        {
+          "name": "disable_email_click_tracking",
+          "baseName": "disable_email_click_tracking",
+          "type": "boolean",
+          "format": ""
         },
         {
             "name": "include_unsubscribed",


### PR DESCRIPTION
close https://github.com/OneSignal/onesignal-node-api/issues/61

# Description
## One Line Summary
Add the missing REST API parameter disable_email_click_tracking

## Details

### Motivation
The parameter of the REST API create email message `disable_email_click_tracking` (https://documentation.onesignal.com/reference/email#disable_email_click_tracking) is missing in the Notification model. Without this users won't be able to disable link tracking using the node api sdk, which is important for transactional emails and could affect email inbox placement.

### Scope
Links in emails are not wrapped with trackable links when `disable_email_click_tracking` is set to `true`, not enabled by default.

### OPTIONAL - Other

# Testing

## Manual testing
- `npm run prepare`
- The changes are tested by patching the distributed `@onesignal/node-onesignal` js and d.ts files through `pnpm`, but not on the repository itself as I am not sure about the testing process.


# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.