### PR TITLE
Update docs for org auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ You can configure auth parameters passing them like this:
 
 ```js
 const configuration = OneSignal.createConfiguration({
-    userAuthKey: '<YOUR_USER_AUTH_KEY>',
-    restApiKey: '<YOUR_REST_API_KEY>',
+    userAuthKey: '<YOUR_ORGANIZATION_API_KEY>', // Organization key is only required for creating new apps and other top-level endpoints
+    restApiKey: '<YOUR_REST_API_KEY>', // App rest api key required for most endpoints
 });
 
 const client = new OneSignal.DefaultApi(configuration);
@@ -76,7 +76,7 @@ parameter. You can then use this to modify your configuration object and create 
 const response = await client.createApp(newapp);
 
 const configuration = OneSignal.createConfiguration({
-    userAuthKey: '<YOUR_USER_KEY_TOKEN>',
+    userAuthKey: '<YOUR_ORGANIZATION_API_KEY>',
     restApiKey: response.basic_auth_key,
 });
 


### PR DESCRIPTION
# Description
## One Line Summary
Correct user auth wording to refer to organization auth instead.

## Details

### Motivation
User auth is a legacy concept, it is important the docs in the repo refer to the new organization auth so the documentation is consistent the dashboard and documentation.onesignal.com.

### Scope
Just updating User Auth Organization auth in the readme.

# Testing
N / A

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item